### PR TITLE
feat: Update rebase success message

### DIFF
--- a/rebase/rebase.go
+++ b/rebase/rebase.go
@@ -42,5 +42,6 @@ func Rebase(filePath string) error {
 	if err = tr.SaveTracker(marshalContent); err != nil {
 		return err
 	}
+	fmt.Println("Successfully reverted back to base version")
 	return nil
 }


### PR DESCRIPTION
This PR updates the success message displayed after a successful `rebase` command execution.

**Changes Made:**
- Modified `rebase/rebase.go` to include `fmt.Println("Successfully reverted back to base version")` after a successful `rebase` operation.

**Reason for Change:**
The previous implementation did not explicitly inform the user about the success of the `rebase` command. This change improves user feedback by providing a clear success message, indicating that the file has been successfully reverted back to its base version.